### PR TITLE
Raise error when Gemfile.lock not present

### DIFF
--- a/lib/cc/engine/bundler_audit.rb
+++ b/lib/cc/engine/bundler_audit.rb
@@ -4,6 +4,8 @@ require 'versionomy'
 module CC
   module Engine
     class BundlerAudit
+      GemfileLockNotFound = Class.new(StandardError)
+
       def initialize(directory: , io: , engine_config: )
         @directory = directory
         @engine_config = engine_config
@@ -25,11 +27,7 @@ module CC
             @io.print("#{issue.to_json}\0")
           end
         else
-          warning = {
-            type: "warning",
-            description: "No Gemfile.lock file found"
-          }
-          @io.print("#{warning.to_json}\0")
+          raise GemfileLockNotFound, "No Gemfile.lock found."
         end
       end
 

--- a/spec/cc/engine/bundler_audit_spec.rb
+++ b/spec/cc/engine/bundler_audit_spec.rb
@@ -3,16 +3,15 @@ require "spec_helper"
 module CC::Engine
   describe BundlerAudit do
     describe "#run" do
-      it "emits a warning when no Gemfile exists" do
+      it "raises an error when no Gemfile.lock exists" do
         FakeFS do
           directory = "/c"
           FileUtils.mkdir_p(directory)
           io = StringIO.new
           config = {}
 
-          BundlerAudit.new(directory: directory, io: io, engine_config: config).run
-
-          expect(io.string).to match(%{{"type":"warning","description":"No Gemfile.lock file found"}})
+          expect { BundlerAudit.new(directory: directory, io: io, engine_config: config).run }
+            .to raise_error(CC::Engine::BundlerAudit::GemfileLockNotFound)
         end
       end
 


### PR DESCRIPTION
This change fixes a bug: Previously, when bundler audit
emitted a `warning: no gemfile.lock found` json, it would
cause the snapshot to get stuck in started state. All steps
would finish, but Builder would not send a `done` message.

Context: Bundler-audit reports some repo-wide issues
that do not belong to any single file. In this case for
instance, the issue is that no Gemfile.lock exists.

Since Code Climate does not presently provide an interface
for handling repo-wide issues, the engine should blow up
when this warning is present.

In the future, we want to more smoothly handle reports of
orphan issues.

cc @codeclimate/review @jpignata 