### PR TITLE
update circle.yml for automatic deploy

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -3,23 +3,24 @@ machine:
     - docker
   environment:
     CLOUDSDK_CORE_DISABLE_PROMPTS: 1
-    image_name: codeclimate-bundler-audit
-
-dependencies:
-  pre:
-    - echo $gcloud_json_key_base64 | sed 's/ //g' | base64 -d > /tmp/gcloud_key.json
-    - curl https://sdk.cloud.google.com | bash
-    - gcloud auth activate-service-account $gcloud_account_email --key-file /tmp/gcloud_key.json
-    - gcloud docker -a
+    PRIVATE_REGISTRY: us.gcr.io/code_climate
 
 test:
   override:
     - bundle exec rake
-    - docker build -t=$registry_root/$image_name:b$CIRCLE_BUILD_NUM .
+    - docker build -t=$PRIVATE_REGISTRY/$CIRCLE_PROJECT_REPONAME:b$CIRCLE_BUILD_NUM .
 
 deployment:
   registry:
     branch: master
+    owner: codeclimate
     commands:
-      - docker push $registry_root/$image_name:b$CIRCLE_BUILD_NUM
+      - echo $gcloud_json_key_base64 | sed 's/ //g' | base64 -d > /tmp/gcloud_key.json
+      - curl https://sdk.cloud.google.com | bash
+      - gcloud auth activate-service-account $gcloud_account_email --key-file /tmp/gcloud_key.json
+      - gcloud docker -a
+      - docker push $PRIVATE_REGISTRY/$CIRCLE_PROJECT_REPONAME:b$CIRCLE_BUILD_NUM
 
+notify:
+  webhooks:
+    - url: https://cc-slack-proxy.herokuapp.com/circle


### PR DESCRIPTION
@codeclimate/review @jpignata 

Makes bundler audit autodeploy images from master builds, like the other engines - e.g. [rubocop](https://github.com/codeclimate/codeclimate-rubocop/blob/master/circle.yml)