### PR TITLE
Update ruby-advisory-db prior to running

### DIFF
--- a/lib/cc/engine/bundler_audit.rb
+++ b/lib/cc/engine/bundler_audit.rb
@@ -15,7 +15,7 @@ module CC
       def run
         if gemfile_lock_exists?
           Dir.chdir(@directory)
-          raw_output = `bundle-audit`
+          raw_output = `bundle-audit check --update`
           raw_issues = raw_output.split(/\n\n/).select { |chunk|
             chunk =~ /^Name: /
           }


### PR DESCRIPTION
From my experience, this engine is producing a false positive (no vulnerabilities) due to an outdated ruby-advisory-db. According to the bundler-audit documentation, we should be using `bundle-audit check --update` to update the db prior to auditing the Gemfile.lock (since CC is closer to a CI environment).