### PR TITLE
Bump to bundler-audit 0.4.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     blockenspiel (0.4.5)
-    bundler-audit (0.3.1)
+    bundler-audit (0.4.0)
       bundler (~> 1.2)
       thor (~> 0.18)
     diff-lcs (1.2.5)
@@ -38,4 +38,4 @@ DEPENDENCIES
   versionomy
 
 BUNDLED WITH
-   1.10.3
+   1.11.2


### PR DESCRIPTION
We're a bit behind on bundler-audit itself. We've also missed some changes to the ruby-vulnerabilty-db in the last few days, so we should do a release.