### PR TITLE
Support alphanumeric ruby gem versions

### DIFF
--- a/lib/cc/engine/bundler_audit/unpatched_gem_issue.rb
+++ b/lib/cc/engine/bundler_audit/unpatched_gem_issue.rb
@@ -2,7 +2,7 @@ module CC
   module Engine
     module BundlerAudit
       class UnpatchedGemIssue
-        GEM_REGEX = /^\s*(?<name>\S+) \([\d.]+\)/
+        GEM_REGEX = /^\s*(?<name>\S+) \([\S.]+\)/
         SEVERITIES = {
           high: "critical",
           medium: "normal",

--- a/lib/cc/engine/bundler_audit/unpatched_gem_remediation.rb
+++ b/lib/cc/engine/bundler_audit/unpatched_gem_remediation.rb
@@ -39,13 +39,20 @@ module CC
         end
 
         def current_version
-          @current_version ||= Versionomy.parse(gem_version.to_s)
+          @current_version ||= parse_version(gem_version.to_s)
         end
 
         def upgrade_versions
           @upgrade_versions ||= patched_versions.map do |version|
-            Versionomy.parse(version.to_s)
+            parse_version(version)
           end
+        end
+
+        def parse_version(version)
+          Versionomy.parse(version.to_s)
+        rescue Versionomy::Errors::ParseError
+          version = Versionomy.parse(version.to_s, :rubygems)
+          Versionomy.create(major: version.field0, minor: version.field1, tiny: version.field2)
         end
       end
     end

--- a/spec/cc/engine/bundler_audit/analyzer_spec.rb
+++ b/spec/cc/engine/bundler_audit/analyzer_spec.rb
@@ -30,6 +30,16 @@ module CC::Engine::BundlerAudit
         end
       end
 
+      it "Supports alphanumeric gem versions like 3.0.0.rc.2 or 2.2.2.backport2" do
+        directory = fixture_directory("alphanumeric_versions")
+
+        issues = analyze_directory(directory)
+
+        expected_issues("alphanumeric_versions").each do |expected_issue|
+          expect(issues).to include(expected_issue)
+        end
+      end
+
       it "logs to stderr when we encounter an unsupported vulnerability" do
         directory = fixture_directory("unpatched_versions")
         stderr = StringIO.new

--- a/spec/fixtures/alphanumeric_versions/Gemfile
+++ b/spec/fixtures/alphanumeric_versions/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem "sprockets", "2.2.2.backport2"

--- a/spec/fixtures/alphanumeric_versions/Gemfile.lock
+++ b/spec/fixtures/alphanumeric_versions/Gemfile.lock
@@ -1,0 +1,21 @@
+GEM
+  remote: http://rubygems.org/
+  specs:
+    hike (1.2.3)
+    multi_json (1.11.2)
+    rack (1.4.7)
+    sprockets (2.2.2.backport2)
+      hike (~> 1.2)
+      multi_json (~> 1.0)
+      rack (~> 1.0)
+      tilt (~> 1.1, != 1.3.0)
+    tilt (1.4.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  sprockets (= 2.2.2.backport2)
+
+BUNDLED WITH
+   1.11.2

--- a/spec/fixtures/alphanumeric_versions/issues.json
+++ b/spec/fixtures/alphanumeric_versions/issues.json
@@ -1,0 +1,42 @@
+[
+    {
+        "categories": [
+            "Security"
+        ],
+        "check_name": "Insecure Source",
+        "content": {
+            "body": ""
+        },
+        "description": "Insecure Source URI found: http://rubygems.org/",
+        "location": {
+            "lines": {
+                "begin": 2,
+                "end": 2
+            },
+            "path": "Gemfile.lock"
+        },
+        "remediation_points": 5000000,
+        "severity": "normal",
+        "type": "Issue"
+    },
+    {
+        "categories": [
+            "Security"
+        ],
+        "check_name": "Insecure Dependency",
+        "content": {
+            "body": "**Advisory**: CVE-2014-7819\n\n**Criticality**: Medium\n\n**URL**: https://groups.google.com/forum/#!topic/rubyonrails-security/doAVp0YaTqY\n\n**Solution**: upgrade to ~> 2.0.5, ~> 2.1.4, ~> 2.2.3, ~> 2.3.3, ~> 2.4.6, ~> 2.5.1, ~> 2.7.1, ~> 2.8.3, ~> 2.9.4, ~> 2.10.2, ~> 2.11.3, ~> 2.12.3, >= 3.0.0.beta.3"
+        },
+        "description": "Arbitrary file existence disclosure in Sprockets",
+        "location": {
+            "lines": {
+                "begin": 7,
+                "end": 7
+            },
+            "path": "Gemfile.lock"
+        },
+        "remediation_points": 500000,
+        "severity": "normal",
+        "type": "Issue"
+    }
+]


### PR DESCRIPTION
This PR fixes a couple issues.

 - Expand the gem regex to support alphanumeric gem versions
 - Add handling to convert non-semver ruby versions to standard format

@codeclimate/review :mag_right: