### PR TITLE
Emit a unique fingerprint for issues

### DIFF
--- a/lib/cc/engine/bundler_audit.rb
+++ b/lib/cc/engine/bundler_audit.rb
@@ -1,6 +1,7 @@
 require "bundler/audit/scanner"
 require "json"
 require "versionomy"
+require "digest/md5"
 
 require "cc/engine/bundler_audit/analyzer"
 require "cc/engine/bundler_audit/insecure_source_issue"
@@ -10,6 +11,9 @@ require "cc/engine/bundler_audit/unpatched_gem_remediation"
 module CC
   module Engine
     module BundlerAudit
+      def self.fingerprint_for(check_name, *args)
+        Digest::MD5.new << [check_name, args].flatten.join("|")
+      end
     end
   end
 end

--- a/lib/cc/engine/bundler_audit/insecure_source_issue.rb
+++ b/lib/cc/engine/bundler_audit/insecure_source_issue.rb
@@ -2,6 +2,7 @@ module CC
   module Engine
     module BundlerAudit
       class InsecureSourceIssue
+        CHECK_NAME = "Insecure Source".freeze
         REMEDIATION_POINTS = 5_000_000
         SOURCE_REGEX = /^\s*remote: (?<source>\S+)/
 
@@ -13,7 +14,7 @@ module CC
         def to_json(*a)
           {
             categories: %w[Security],
-            check_name: "Insecure Source",
+            check_name: CHECK_NAME,
             content: {
               body: "",
             },
@@ -28,6 +29,7 @@ module CC
             remediation_points: REMEDIATION_POINTS,
             severity: "normal",
             type: "Issue",
+            fingerprint: BundlerAudit.fingerprint_for(CHECK_NAME, source),
           }.to_json(a)
         end
 

--- a/lib/cc/engine/bundler_audit/unpatched_gem_issue.rb
+++ b/lib/cc/engine/bundler_audit/unpatched_gem_issue.rb
@@ -2,6 +2,7 @@ module CC
   module Engine
     module BundlerAudit
       class UnpatchedGemIssue
+        CHECK_NAME = "Insecure Dependency".freeze
         GEM_REGEX = /^\s*(?<name>\S+) \([\S.]+\)/
         SEVERITIES = {
           high: "critical",
@@ -18,7 +19,7 @@ module CC
         def to_json(*a)
           {
             categories: %w[Security],
-            check_name: "Insecure Dependency",
+            check_name: CHECK_NAME,
             content: {
               body: content_body,
             },
@@ -33,6 +34,7 @@ module CC
             remediation_points: remediation_points,
             severity: severity,
             type: "Issue",
+            fingerprint: fingerprint,
           }.to_json(a)
         end
 
@@ -83,6 +85,10 @@ module CC
           when advisory.cve then "CVE-#{advisory.cve}"
           when advisory.osvdb then advisory.osvdb
           end
+        end
+
+        def fingerprint
+          BundlerAudit.fingerprint_for(CHECK_NAME, gem, advisory.id)
         end
       end
     end

--- a/spec/fixtures/alphanumeric_versions/issues.json
+++ b/spec/fixtures/alphanumeric_versions/issues.json
@@ -17,7 +17,8 @@
         },
         "remediation_points": 5000000,
         "severity": "normal",
-        "type": "Issue"
+        "type": "Issue",
+        "fingerprint": "dc0e043c56c03c2ada6c448f1958cfcb"
     },
     {
         "categories": [
@@ -37,6 +38,7 @@
         },
         "remediation_points": 500000,
         "severity": "normal",
-        "type": "Issue"
+        "type": "Issue",
+        "fingerprint": "d46fd8d3ccc9459f81fb4724ef158fdf"
     }
 ]

--- a/spec/fixtures/insecure_sources/issues.json
+++ b/spec/fixtures/insecure_sources/issues.json
@@ -17,7 +17,8 @@
         },
         "remediation_points": 5000000,
         "severity": "normal",
-        "type": "Issue"
+        "type": "Issue",
+        "fingerprint": "c17a91d7c242cbb1d217b3b9f8a6b306"
     },
     {
         "categories": [
@@ -37,6 +38,7 @@
         },
         "remediation_points": 5000000,
         "severity": "normal",
-        "type": "Issue"
+        "type": "Issue",
+        "fingerprint": "dc0e043c56c03c2ada6c448f1958cfcb"
     }
 ]

--- a/spec/fixtures/unpatched_versions/issues.json
+++ b/spec/fixtures/unpatched_versions/issues.json
@@ -17,7 +17,8 @@
         },
         "remediation_points": 50000,
         "severity": "normal",
-        "type": "Issue"
+        "type": "Issue",
+        "fingerprint": "06ae795b91e09069846af543d755b9e1"
     },
     {
         "categories": [
@@ -37,7 +38,8 @@
         },
         "remediation_points": 50000,
         "severity": "normal",
-        "type": "Issue"
+        "type": "Issue",
+        "fingerprint": "98b8ca0112bff7bf79c1a85a829cf948"
     },
     {
         "categories": [
@@ -57,7 +59,8 @@
         },
         "remediation_points": 50000,
         "severity": "normal",
-        "type": "Issue"
+        "type": "Issue",
+        "fingerprint": "fb0889d061f06c4203ed27b43aca68b2"
     },
     {
         "categories": [
@@ -77,7 +80,8 @@
         },
         "remediation_points": 50000,
         "severity": "normal",
-        "type": "Issue"
+        "type": "Issue",
+        "fingerprint": "f26c202060c497fd32f90c538c543445"
     },
     {
         "categories": [
@@ -97,7 +101,8 @@
         },
         "remediation_points": 50000,
         "severity": "normal",
-        "type": "Issue"
+        "type": "Issue",
+        "fingerprint": "723fd12f6da25240ffbf2f3312b8e33d"
     },
     {
         "categories": [
@@ -117,7 +122,8 @@
         },
         "remediation_points": 50000,
         "severity": "normal",
-        "type": "Issue"
+        "type": "Issue",
+        "fingerprint": "2441a69a4af613e9235af4024ff21b30"
     },
     {
         "categories": [
@@ -137,7 +143,8 @@
         },
         "remediation_points": 5000000,
         "severity": "normal",
-        "type": "Issue"
+        "type": "Issue",
+        "fingerprint": "c1c5e720803020244d18bddad5f5f790"
     },
     {
         "categories": [
@@ -157,7 +164,8 @@
         },
         "remediation_points": 500000,
         "severity": "normal",
-        "type": "Issue"
+        "type": "Issue",
+        "fingerprint": "20188b3cc82f969dea234989e92339d4"
     },
     {
         "categories": [
@@ -177,7 +185,8 @@
         },
         "remediation_points": 50000,
         "severity": "normal",
-        "type": "Issue"
+        "type": "Issue",
+        "fingerprint": "65fefc6b16a09d76d5c76b03247a48e1"
     },
     {
         "categories": [
@@ -197,7 +206,8 @@
         },
         "remediation_points": 500000,
         "severity": "normal",
-        "type": "Issue"
+        "type": "Issue",
+        "fingerprint": "b344012bca53e8faaafbf0f943776ea0"
     },
     {
         "categories": [
@@ -217,7 +227,8 @@
         },
         "remediation_points": 500000,
         "severity": "normal",
-        "type": "Issue"
+        "type": "Issue",
+        "fingerprint": "10818805098b10f2fe6e181f0961445c"
     },
     {
         "categories": [
@@ -237,6 +248,7 @@
         },
         "remediation_points": 5000000,
         "severity": "normal",
-        "type": "Issue"
+        "type": "Issue",
+        "fingerprint": "118e36b455317d002e7fde24873ecc40"
     }
 ]


### PR DESCRIPTION
Previously this engine did not emit a fingerprint for any issues which
resulted in Code Climate assigning a default fingerprint. As the
the default fingerprint is just a concatenation of the path of the file
and the check name, only two fingerprints were possible depending on
which check emitted the issue.

Instead, use details from the issue to calculate a fingerprint. For an
insecure source, use the source and for a gem use the gem name and the
advisory ID.

@codeclimate/review