### PR TITLE
Slim down docker image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,11 @@
 FROM codeclimate/alpine-ruby:b38
 
 WORKDIR /usr/src/app
-RUN apk --update add ruby ruby-dev ruby-bundler build-base git
+RUN apk --update add ruby ruby-bundler git
 
-COPY Gemfile /usr/src/app/
-COPY Gemfile.lock /usr/src/app/
-RUN bundle install -j 4 && \
-    apk del build-base && rm -fr /usr/share/ri
+COPY Gemfile* /usr/src/app/
+RUN bundle install --jobs 4 && \
+    rm -rf /usr/share/ri
 
 RUN adduser -u 9000 -D app
 USER app
@@ -16,4 +15,3 @@ RUN bundle-audit update
 COPY . /usr/src/app
 
 CMD ["/usr/src/app/bin/bundler-audit"]
-

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,6 @@
 source "https://rubygems.org"
 
 gem "bundler-audit", "~> 0.4.0"
-gem "json", "~> 1.8.3"
 gem "versionomy", "~> 0.5.0"
 gem "rake"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,6 @@ GEM
       bundler (~> 1.2)
       thor (~> 0.18)
     diff-lcs (1.2.5)
-    json (1.8.3)
     rake (10.4.2)
     rspec (3.3.0)
       rspec-core (~> 3.3.0)
@@ -30,7 +29,6 @@ PLATFORMS
 
 DEPENDENCIES
   bundler-audit (~> 0.4.0)
-  json (~> 1.8.3)
   rake
   rspec
   versionomy (~> 0.5.0)


### PR DESCRIPTION
This PR reduces this engine's docker engine size to ~50MB from ~200MB, mainly by removing the [json gem][] (with native C extension) dependency. JSON support within Ruby's standard library should be fast enough, especially considering that this engine usually doesn't output a ton of issues for a particular codebase.

@codeclimate/review :mag_right:

[json gem]: https://github.com/flori/json