### PR TITLE
Update bundler-audit to v0.5.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-gem "bundler-audit", "~> 0.4.0"
+gem "bundler-audit", "~> 0.5.0"
 gem "versionomy", "~> 0.5.0"
 gem "rake"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     blockenspiel (0.5.0)
-    bundler-audit (0.4.0)
+    bundler-audit (0.5.0)
       bundler (~> 1.2)
       thor (~> 0.18)
     diff-lcs (1.2.5)
@@ -28,7 +28,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bundler-audit (~> 0.4.0)
+  bundler-audit (~> 0.5.0)
   rake
   rspec
   versionomy (~> 0.5.0)

--- a/lib/cc/engine/bundler_audit/unpatched_gem_issue.rb
+++ b/lib/cc/engine/bundler_audit/unpatched_gem_issue.rb
@@ -87,7 +87,7 @@ module CC
         end
 
         def identifier
-          advisory.cve_id || advisory.osvdb
+          advisory.cve_id || advisory.osvdb_id
         end
 
         def fingerprint

--- a/lib/cc/engine/bundler_audit/unpatched_gem_issue.rb
+++ b/lib/cc/engine/bundler_audit/unpatched_gem_issue.rb
@@ -87,10 +87,7 @@ module CC
         end
 
         def identifier
-          case
-          when advisory.cve then "CVE-#{advisory.cve}"
-          when advisory.osvdb then advisory.osvdb
-          end
+          advisory.cve_id || advisory.osvdb
         end
 
         def fingerprint

--- a/spec/fixtures/unpatched_versions/issues.json
+++ b/spec/fixtures/unpatched_versions/issues.json
@@ -257,7 +257,7 @@
         ],
         "check_name": "Insecure Dependency",
         "content": {
-            "body": "**Advisory**: 126747\n\n**URL**: https://github.com/mishoo/UglifyJS2/issues/751\n\n**Solution**: upgrade to >= 2.7.2"
+            "body": "**Advisory**: OSVDB-126747\n\n**URL**: https://github.com/mishoo/UglifyJS2/issues/751\n\n**Solution**: upgrade to >= 2.7.2"
         },
         "description": "uglifier incorrectly handles non-boolean comparisons during minification",
         "fingerprint": "118e36b455317d002e7fde24873ecc40",


### PR DESCRIPTION
- Update bundler-audit to v0.5.0
- Use new `Advisory#cve_id` and `Advisory#osvdb_id` methods

@codeclimate/review :mag_right: