### PR TITLE
Update bundler-audit to 0.6.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,34 @@
-FROM codeclimate/alpine-ruby:b38
-
-WORKDIR /usr/src/app
-RUN apk --update add ruby ruby-bundler git
-
-COPY Gemfile* /usr/src/app/
-RUN bundle install --jobs 4 && \
-    rm -rf /usr/share/ri
+FROM alpine:3.6
 
 RUN adduser -u 9000 -D app
-USER app
+
+WORKDIR /usr/src/app
+
+RUN apk add --no-cache ruby ruby-json git && \
+  gem install --no-ri --no-rdoc bundler && \
+  rm -r ~/.gem
+
+COPY Gemfile* /usr/src/app/
+RUN bundle install --without=test --no-cache && \
+    rm -rf ~/.bundle /usr/lib/ruby/gems/2.4.0/cache/* /usr/share/ri
 
 COPY DATABASE_VERSION /usr/src/app/DATABASE_VERSION
 
-RUN bundle-audit update
+COPY bin bin/
+COPY lib lib/
+RUN chown -R app:app .
 
-COPY . /usr/src/app
+USER app
+
+# The following step has to be ran by app user aas it depends on $HOME
+RUN bundle-audit update && \
+  for f in ~/.local/share/ruby-advisory-db/*  ~/.local/share/ruby-advisory-db/.*; do \
+    name="$(basename "$f")"; \
+    test "$name" = "gems" || \
+      test "$name" = "." || \
+      test "$name" = ".." || \
+      test "$name" = ".git" || \
+      rm -r "$f"; \
+  done
 
 CMD ["/usr/src/app/bin/bundler-audit"]

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,0 +1,13 @@
+FROM codeclimate/codeclimate-bundler-audit
+
+USER root
+
+RUN bundler install --no-cache --with="development test"
+
+COPY Rakefile ./
+COPY spec spec/
+RUN chown -R app:app Rakefile spec
+
+user app
+
+CMD ["bundle", "exec", "rake"]

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,11 @@
 source "https://rubygems.org"
 
-gem "bundler-audit", "~> 0.5.0"
+gem "bundler-audit", "~> 0.6.0"
 gem "versionomy", "~> 0.5.0"
-gem "rake"
+
+group :development do
+  gem "rake"
+end
 
 group :test do
   gem "pry"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,32 +2,31 @@ GEM
   remote: https://rubygems.org/
   specs:
     blockenspiel (0.5.0)
-    bundler-audit (0.5.0)
+    bundler-audit (0.6.0)
       bundler (~> 1.2)
       thor (~> 0.18)
-    coderay (1.1.1)
-    diff-lcs (1.2.5)
-    method_source (0.8.2)
-    pry (0.10.4)
+    coderay (1.1.2)
+    diff-lcs (1.3)
+    json (2.1.0)
+    method_source (0.9.0)
+    pry (0.11.3)
       coderay (~> 1.1.0)
-      method_source (~> 0.8.1)
-      slop (~> 3.4)
-    rake (10.4.2)
-    rspec (3.3.0)
-      rspec-core (~> 3.3.0)
-      rspec-expectations (~> 3.3.0)
-      rspec-mocks (~> 3.3.0)
-    rspec-core (3.3.1)
-      rspec-support (~> 3.3.0)
-    rspec-expectations (3.3.0)
+      method_source (~> 0.9.0)
+    rake (12.2.1)
+    rspec (3.7.0)
+      rspec-core (~> 3.7.0)
+      rspec-expectations (~> 3.7.0)
+      rspec-mocks (~> 3.7.0)
+    rspec-core (3.7.0)
+      rspec-support (~> 3.7.0)
+    rspec-expectations (3.7.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.3.0)
-    rspec-mocks (3.3.1)
+      rspec-support (~> 3.7.0)
+    rspec-mocks (3.7.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.3.0)
-    rspec-support (3.3.0)
-    slop (3.6.0)
-    thor (0.19.1)
+      rspec-support (~> 3.7.0)
+    rspec-support (3.7.0)
+    thor (0.20.0)
     versionomy (0.5.0)
       blockenspiel (~> 0.5)
 
@@ -35,11 +34,12 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bundler-audit (~> 0.5.0)
+  bundler-audit (~> 0.6.0)
+  json
   pry
   rake
   rspec
   versionomy (~> 0.5.0)
 
 BUNDLED WITH
-   1.15.3
+   1.16.0

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,20 @@
 .PHONY: image test citest update_version
 
 IMAGE_NAME ?= codeclimate/codeclimate-bundler-audit
+TEST_IMAGE_NAME ?= $(IMAGE_NAME)-test
 
 image:
 	docker build --rm -t $(IMAGE_NAME) .
 
-test: image
-	docker run -e PAGER=more --tty --interactive --rm $(IMAGE_NAME) bundle exec rake
+test-image: image
+	docker build --rm -t $(TEST_IMAGE_NAME) -f Dockerfile.test .
 
-citest:
-	docker run --rm $(IMAGE_NAME) bundle exec rake
+test:
+	@$(MAKE) test-image > /dev/null
+	docker run \
+        -e PAGER=more \
+        --tty --interactive --rm \
+        $(TEST_IMAGE_NAME)
 
 update_database:
 	date > DATABASE_VERSION

--- a/circle.yml
+++ b/circle.yml
@@ -12,11 +12,11 @@ dependencies:
       --env GCR_JSON_KEY
       --volume /var/run/docker.sock:/var/run/docker.sock
       codeclimate/patrick pull || true
-    - make image
+    - make test-image
 
 test:
   override:
-    - make citest
+    - make test
 
 deployment:
   registry:

--- a/lib/cc/engine/bundler_audit/analyzer.rb
+++ b/lib/cc/engine/bundler_audit/analyzer.rb
@@ -1,3 +1,5 @@
+require "tmpdir"
+
 module CC
   module Engine
     module BundlerAudit


### PR DESCRIPTION
This PR bumps bundler-audit to 0.6.0. There are no cs in it that are relevant to the engine.

However, another issue is fixed within this PR. Updated bundler-audit db was inaccessible in the older images because it wasn't transferred to the `app` user.

In addition the final image has been slimmed down a bit by moving test-related code out of it.