### PR TITLE
QUA-958: Deprecate image push to GCR

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,7 @@ jobs:
               circleci step halt
             fi
       - run: make image
+      - run: echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
       - run: bin/deploy
       - run: send_webhook
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,6 @@ jobs:
               circleci step halt
             fi
       - run: make image
-      - run: echo "$GCR_JSON_KEY" | docker login -u _json_key --password-stdin us.gcr.io
       - run: bin/deploy
       - run: send_webhook
 

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,11 @@
 
 IMAGE_NAME ?= codeclimate/codeclimate-bundler-audit
 RELEASE_REGISTRY ?= codeclimate
-RELEASE_TAG ?= latest
 TEST_IMAGE_NAME ?= $(IMAGE_NAME)-test
+
+ifndef RELEASE_TAG
+override RELEASE_TAG = latest
+endif
 
 image:
 	docker build --rm -t $(IMAGE_NAME) .

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: image test citest update_database release
 
 IMAGE_NAME ?= codeclimate/codeclimate-bundler-audit
-RELEASE_REGISTRY ?= us.gcr.io/code_climate
+RELEASE_REGISTRY ?= codeclimate
 RELEASE_TAG ?= latest
 TEST_IMAGE_NAME ?= $(IMAGE_NAME)-test
 

--- a/bin/deploy
+++ b/bin/deploy
@@ -7,6 +7,14 @@ case "$CIRCLE_BRANCH" in
     make release \
      RELEASE_TAG="b$CIRCLE_BUILD_NUM"
     ;;
+  channel/*)
+    make release
+    make release \
+     RELEASE_TAG="b$CIRCLE_BUILD_NUM"
+    ;;
+    make release \
+     RELEASE_TAG="$(echo $CIRCLE_BRANCH | grep -oP 'channel/\K[\w\-]+')"
+    ;;
   *)
     echo "Not releasing image from feature branches"
     ;;

--- a/bin/deploy
+++ b/bin/deploy
@@ -8,7 +8,6 @@ case "$CIRCLE_BRANCH" in
      RELEASE_TAG="b$CIRCLE_BUILD_NUM"
     ;;
   channel/*)
-    make release
     make release \
      RELEASE_TAG="b$CIRCLE_BUILD_NUM"
     make release \

--- a/bin/deploy
+++ b/bin/deploy
@@ -11,7 +11,6 @@ case "$CIRCLE_BRANCH" in
     make release
     make release \
      RELEASE_TAG="b$CIRCLE_BUILD_NUM"
-    ;;
     make release \
      RELEASE_TAG="$(echo $CIRCLE_BRANCH | grep -oP 'channel/\K[\w\-]+')"
     ;;


### PR DESCRIPTION
- Change deploy logic to not push images to GCR. Instead, images will be deployed directly to Dockerhub. For this, we need to tag images both with the `$CIRCLE_BUILD_NUM` and the engine's channel.